### PR TITLE
Fixed issue with dependency injection for the twig_js assetic filter

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -22,7 +22,7 @@
             <argument type="service" id="twig_js.compiler" />
         </service>
     
-        <service id="twig_js.assetic_filter" class="%twig_js.assetic_filter.class%">
+        <service id="assetic.filter.twig_js" class="%twig_js.assetic_filter.class%">
             <argument type="service" id="twig_js.compile_request_handler" />
             <tag name="assetic.filter" alias="twig_js" />
         </service>


### PR DESCRIPTION
As of now, there is an issue preventing the Assetic from loading the filter if the name of the service associated to the filter doesn't respect the assetic.filter.filter_name convention.

```
[Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException]                                
The service "assetic.asset_factory" has a dependency on a non-existent service "assetic.filter.twig_js".
```

This code fixes that issue, by renaming the twig_js.assetic_filter service into assetic.filter.twig_js
