### PR TITLE
Fixing operator precedence issue in TransFilterCompiler

### DIFF
--- a/TwigJs/Compiler/TransFilterCompiler.php
+++ b/TwigJs/Compiler/TransFilterCompiler.php
@@ -25,7 +25,7 @@ class TransFilterCompiler implements FilterCompilerInterface
 
     public function compile(JsCompiler $compiler, \Twig_Node_Expression_Filter $node)
     {
-        if (!$locale = $compiler->getDefine('locale') || !$this->translator instanceof Translator) {
+        if (!($locale = $compiler->getDefine('locale')) || !$this->translator instanceof Translator) {
             return false;
         }
 


### PR DESCRIPTION
These days I've noticed that the twigjs templates of the application I'm working on were always translated with the fallback locale.  I've found out it was due to the following expression of the _TransFilterCompiler#compile_ method :

`if (!$locale = $compiler->getDefine('locale') || !$this->translator instanceof Translator) ...`

The '||' operator having a higher precedence than the assignment operator, the _$locale_ variable is always assigned with the value of the '||' expression, i.e. a boolean value. Consequently, the translator is unable to load the expected catalogue and defaults to the fallback one.

I assume the problem occured with the last dependencies update I've made, because I've never encountered such a behaviour, and I honestly don't know how this line of code could work as expected. 
