### PR TITLE
Added initial inline js routing functionality

### DIFF
--- a/DependencyInjection/Compiler/MountFunctionCompilersPass.php
+++ b/DependencyInjection/Compiler/MountFunctionCompilersPass.php
@@ -42,18 +42,25 @@ class MountFunctionCompilersPass implements CompilerPassInterface
 
         $compiler = $container->getDefinition('twig_js.compiler');
 
+        // Find the tagged function compilers and add them to the javascript
+        // compiler
         foreach ($container->findTaggedServiceIds('twig_js.function_compiler')
             as $id => $tags) {
             foreach ($tags as $tag) {
                 if (!array_key_exists('function', $tag)) {
-                    var_dump($tag);
                     throw new \LogicException("When defining a TwigJS function complier you must specify the function name in the service tags 'function' attribute.");
                 }
 
-                $compiler->addMethodCall('setFunctionCompiler', array(
-                    $tag['function'],
-                    new Reference($id),
-                ));
+                // Function parameters
+                $params = array($tag['function'], new Reference($id));
+
+                // Add the priority if it has been set on the tag
+                if (array_key_exists('priority', $tag)) {
+                    $params[] = (int) $tag['priority'];
+                }
+
+                // Add the function compiler dependancy
+                $compiler->addMethodCall('addFunctionCompiler', $params);
             }
         }
     }

--- a/DependencyInjection/Compiler/MountFunctionCompilersPass.php
+++ b/DependencyInjection/Compiler/MountFunctionCompilersPass.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\TwigJsBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+
+/**
+ * Mount Function Compiler Pass
+ *
+ * This compiler pass finds services which are tagged as function compilers and
+ * adds them to the twig js compiler.
+ *
+ * @author Josiah <josiah@jjs.id.au>
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+class MountFunctionCompilersPass implements CompilerPassInterface
+{
+    /** {@inheritdoc} */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('twig_js.compiler')) {
+            return;
+        }
+
+        $compiler = $container->getDefinition('twig_js.compiler');
+
+        foreach ($container->findTaggedServiceIds('twig_js.function_compiler')
+            as $id => $tags) {
+            foreach ($tags as $tag) {
+                if (!array_key_exists('function', $tag)) {
+                    var_dump($tag);
+                    throw new \LogicException("When defining a TwigJS function complier you must specify the function name in the service tags 'function' attribute.");
+                }
+
+                $compiler->addMethodCall('setFunctionCompiler', array(
+                    $tag['function'],
+                    new Reference($id),
+                ));
+            }
+        }
+    }
+}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -37,6 +37,28 @@ class Configuration implements ConfigurationInterface
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('twig_js');
 
+        $rootNode
+            ->children()
+                ->arrayNode('route_compilation')
+                    ->info("Enables inline route compilation")
+                    ->treatFalseLike(array('url' => false, 'path' => false))
+                    ->treatTrueLike(array('url' => true, 'path' => true))
+                    ->treatNullLike(array('url' => true, 'path' => true))
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->booleanNode('url')
+                            ->defaultFalse()
+                            ->treatNullLike(false)
+                        ->end()
+                        ->booleanNode('path')
+                            ->defaultFalse()
+                            ->treatNullLike(false)
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
+
         return $treeBuilder;
     }
 }

--- a/DependencyInjection/JMSTwigJsExtension.php
+++ b/DependencyInjection/JMSTwigJsExtension.php
@@ -42,6 +42,30 @@ class JMSTwigJsExtension extends Extension
         $loader->load('services.xml');
         $loader->load('filters.xml');
         $loader->load('functions.xml');
+
+        // Load the route compilation if it is defined
+        if (array_key_exists('route_compilation', $config)) {
+            $this->loadRouteCompilationConfig($config['route_compilation'], $container);
+        }
+    }
+
+    /**
+     * Configure the service container for route compilation
+     *
+     * @param array            $config    Route compilation configuration
+     * @param ContainerBuilder $container Service container
+     */
+    protected function loadRouteCompilationConfig(array $config, ContainerBuilder $container)
+    {
+        $routingCompiler = $container->getDefinition('twig_js.functions.routing_compiler');
+
+        if ($config['path']) {
+            $routingCompiler->addTag('twig_js.function_compiler', array('function' => 'path'));
+        }
+
+        if ($config['url']) {
+            $routingCompiler->addTag('twig_js.function_compiler', array('function' => 'url'));
+        }
     }
 
     public function getAlias()

--- a/DependencyInjection/JMSTwigJsExtension.php
+++ b/DependencyInjection/JMSTwigJsExtension.php
@@ -41,6 +41,7 @@ class JMSTwigJsExtension extends Extension
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
         $loader->load('filters.xml');
+        $loader->load('functions.xml');
     }
 
     public function getAlias()

--- a/JMSTwigJsBundle.php
+++ b/JMSTwigJsBundle.php
@@ -19,6 +19,7 @@
 namespace JMS\TwigJsBundle;
 
 use JMS\TwigJsBundle\DependencyInjection\Compiler\MountFilterCompilersPass;
+use JMS\TwigJsBundle\DependencyInjection\Compiler\MountFunctionCompilersPass;
 use JMS\TwigJsBundle\DependencyInjection\JMSTwigJsExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -33,5 +34,6 @@ class JMSTwigJsBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         $container->addCompilerPass(new MountFilterCompilersPass());
+        $container->addCompilerPass(new MountFunctionCompilersPass());
     }
 }

--- a/Resources/config/functions.xml
+++ b/Resources/config/functions.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="twig_js.function.routing_compiler.class">JMS\TwigJsBundle\TwigJs\Compiler\RoutingFunctionCompiler</parameter>
+    </parameters>
+
+    <services>
+        <!--
+            Routing Compiler
+
+            @see JMS\TwigJsBundle\TwigJs\Compiler\RoutingFunctionCompiler
+        -->
+        <service id="twig_js.functions.routing_compiler" class="%twig_js.function.routing_compiler.class%" public="false">
+            <tag name="twig_js.function_compiler" function="url" />
+            <tag name="twig_js.function_compiler" function="path" />
+            <argument type="service" id="router" />
+        </service>
+    </services>
+</container>

--- a/Resources/config/functions.xml
+++ b/Resources/config/functions.xml
@@ -9,14 +9,7 @@
     </parameters>
 
     <services>
-        <!--
-            Routing Compiler
-
-            @see JMS\TwigJsBundle\TwigJs\Compiler\RoutingFunctionCompiler
-        -->
         <service id="twig_js.functions.routing_compiler" class="%twig_js.function.routing_compiler.class%" public="false">
-            <tag name="twig_js.function_compiler" function="url" />
-            <tag name="twig_js.function_compiler" function="path" />
             <argument type="service" id="router" />
         </service>
     </services>

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -55,6 +55,14 @@ to specify all of them.
 
 See twig.js_ documentation for how to render your templates.
 
+Router Integration
+~~~~~~~~~~~~~~~~~~
+
+You can integrate the symfony2 router into twig.js_ using built in features
+or other libraries. See `Routing Integration`_ for more information.
+
+.. _`Routing Integration`: routing.rst
+
 Custom Integration
 ~~~~~~~~~~~~~~~~~~
 If you need to customize your integration, this bundle makes a service named

--- a/Resources/doc/routing.rst
+++ b/Resources/doc/routing.rst
@@ -21,9 +21,8 @@ How to enable this feature
 
 Add the following lines to your application configuration:
 
-```yaml
-# app/config/config.yml
-twig_js:
+::
+    # app/config/config.yml
+    twig_js:
 
-    route_compilation: true
-```
+        route_compilation: true

--- a/Resources/doc/routing.rst
+++ b/Resources/doc/routing.rst
@@ -1,0 +1,29 @@
+===================
+Routing Integration
+===================
+
+Routing information from your symfony application can be integrated your
+compiled javascript templates either through inline route compilation or by
+integrating an javascript routing solution (such as the FOSJsRoutingBundle_).
+
+.. _FOSJsRoutingBundle: https://github.com/FriendsOfSymfony/FOSJsRoutingBundle
+
+Inline Route Compilation
+========================
+
+The easiest method of integration routing information is to take advantage of
+the built in inline route compilation functionality. This funcionality
+interprets a route and produces a javascript function which will generate a url
+the same as symfony would.
+
+How to enable this feature
+--------------------------
+
+Add the following lines to your application configuration:
+
+```yaml
+# app/config/config.yml
+twig_js:
+
+    route_compilation: true
+```

--- a/Resources/doc/routing.rst
+++ b/Resources/doc/routing.rst
@@ -22,6 +22,7 @@ How to enable this feature
 Add the following lines to your application configuration:
 
 ::
+
     # app/config/config.yml
     twig_js:
 

--- a/TwigJs/Compiler/RoutingFunctionCompiler.php
+++ b/TwigJs/Compiler/RoutingFunctionCompiler.php
@@ -1,0 +1,226 @@
+<?php
+
+/*
+ * Copyright 2013 Josiah Truasheim <josiah@jjs.id.au>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\TwigJsBundle\TwigJs\Compiler;
+
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Routing\Route;
+use Twig_Node_Expression_Function;
+use Twig_Node_Expression_Constant;
+use Twig_NodeInterface;
+use TwigJs\FunctionCompilerInterface;
+use TwigJs\JsCompiler;
+
+/**
+ * Routing Function Compiler
+ *
+ * Compiles routing functions (`path` and `url`) into javascript inline closures
+ * which will generate routes in isolation.
+ *
+ * @author Josiah <josiah@jjs.id.au>
+ */
+class RoutingFunctionCompiler implements FunctionCompilerInterface
+{
+    /**
+     * Router
+     * 
+     * @var RouterInterface
+     */
+    protected $router;
+
+    /**
+     * @param RouterInterface $router Router
+     */
+    public function __construct(RouterInterface $router)
+    {
+        $this->router = $router;
+    }
+
+    /**
+     * Compiles a twig function for use in javascript and compiles a method call
+     * appropriate for the specified node.
+     * 
+     * @param JsCompiler                    $compiler Javascript twig compiler
+     * @param Twig_Node_Expression_Function $node     Node for compilation
+     */
+    public function compile(JsCompiler $compiler, Twig_Node_Expression_Function $functionNode)
+    {
+        // Function arguments
+        $argumentNodes = iterator_to_array($functionNode->getNode('arguments'));
+
+        // Ensure that the argument list is not empty
+        if (empty($argumentNodes)) {
+            throw new \RuntimeException(sprintf(
+                "Can't compile %s function for javascript when no arguments are provided.",
+                $functionNode->getAttribute('name')
+            ));
+        }
+
+        // First argument will be the route
+        $routeNode = array_shift($argumentNodes);
+
+        // Only text nodes are supported as the routing path
+        if ($routeNode instanceof Twig_Node_Expression_Constant) {
+            $routeName = $routeNode->getAttribute('value');
+        } else {
+            $compiler
+                ->raw("(function(){throw ")
+                ->string(sprintf(
+                    "Only static route names can be compiled for javascript %s. Node type '%s' is not supported.",
+                    $node->getAttribute('name'),
+                    get_class($routeNode)
+                ))
+                ->raw(";})()")
+            ;
+            return;
+        }
+
+        // Get the route name from the node
+        $route = $this->router->getRouteCollection()->get($routeName);
+
+        // When no route exists throw an exception
+        if (!$route) {
+            $compiler
+                ->raw("(function(){throw ")
+                ->string(sprintf("Can't find route named '%s'", $routeName))
+                ->raw(";})()")
+            ;
+            return;
+        }
+
+        // Open lambda
+        $compiler->raw('(');
+
+        // Compile the route into javascript function
+        $this->compileRouteFunction($compiler, $route, $functionNode->getAttribute('name') === 'url');
+
+        // Close lambda
+        $compiler->raw(')');
+
+        // Compile remaining arguments
+        $compiler->raw('(');
+        foreach ($argumentNodes as $index => $argumentNode) {
+            if ($index) {
+                $compiler->raw(', ');
+            }
+            $compiler->subcompile($argumentNode);
+        }
+        $compiler->raw(')');
+    }
+
+    /**
+     * Compiles the specified route for use as a javascript closure
+     * 
+     * @param JsCompiler $compiler  Javascipt twig compiler
+     * @param string     $routeName Route name
+     * @param boolean    $url       TRUE if the route should be compiled as a
+     *                              full url; FALSE otherwise.
+     */
+    protected function compileRouteFunction(JsCompiler $compiler, Route $route, $url = false)
+    {
+        // Compile the route
+        $compiledRoute = $route->compile();
+        $defaults = $route->getDefaults();
+
+        // Open the route function
+        $compiler->raw("function (params) {\n");
+        $compiler->indent();
+
+        // Store url informatio in a variable
+        $compiler->write("var url = '';\n");
+
+        // Start the route with the static prefix
+        foreach ($compiledRoute->getTokens() as $token) {
+            list($type, $variable, $requirement, $name) = $token;
+
+            if ($type === 'variable') {
+                // Check route parameters
+                // TODO: Emulate the parameter checking in the url generator
+                
+                // Parameter variables
+                $compiler
+                    ->write("url = ")
+                    ->raw("(encodeURIComponent(params[")
+                    ->string($name)
+                    ->raw(")]||")
+                ;
+
+                // Default value
+                if (array_key_exists($name, $defaults)) {
+                    $compiler->string($this->recodeUrl($defaults[$name]));
+                } else {
+                    $compiler->string("");
+                }
+
+                // Prepend to the url
+                $compiler->raw("))+url;\n");
+            } else {
+                // Static text
+                $compiler
+                    ->write("url = ")
+                    ->string($this->recodeUrl($variable))
+                    ->raw("+url;\n")
+                ;
+                
+            }
+        }
+
+        // Empty urls should be replaced with a slash
+        $compiler
+            ->write("url = url || ")
+            ->string("/")
+            ->raw(";\n")
+        ;
+
+        // Scheme and server are required for full urls
+        // TODO: Add support for the 'url' function
+        
+        // Return the generated url
+        $compiler->write("return url;\n");
+
+        // Close the route function
+        $compiler->outdent();
+        $compiler->write('}');
+    }
+
+    /**
+     * Recodes the url to match with the expectations of symfony
+     * 
+     * @param string $url Url
+     * @return string
+     */
+    protected function recodeUrl($url)
+    {
+        // Base url is already encoded
+        //  see Symfony\Component\HttpFoundation\Request
+        //  and Symfony\Component\Routing\Generator\UrlGenerator->doGenerate()
+        //  and Symfony\Component\Routing\Generator\UrlGenerator->$decodedChars
+        return strtr(rawurlencode($url), array(
+            '%2F' => '/',
+            '%40' => '@',
+            '%3A' => ':',
+            '%3B' => ';',
+            '%2C' => ',',
+            '%3D' => '=',
+            '%2B' => '+',
+            '%21' => '!',
+            '%2A' => '*',
+            '%7C' => '|',
+        ));
+    }
+}


### PR DESCRIPTION
Compiles routing information to inline js closures negating the need to use an external js routing library.

This PR is a work in progress and isn't ready to be merged yet.
