### PR TITLE
Add support for Symfony2.3 and correct some unit tests

### DIFF
--- a/Tests/TwigJs/Compiler/TransFilterCompilerTest.php
+++ b/Tests/TwigJs/Compiler/TransFilterCompilerTest.php
@@ -18,7 +18,7 @@ class TransFilterCompilerTest extends BaseTestCase
         $this->compiler->setDefine('locale', 'de');
         $this->addMessages(array('foo' => 'bar'), 'messages', 'de');
 
-        $this->assertContains('sb.append("bar");', $this->compile('{{ "foo"|trans|raw }}'));
+        $this->assertContains('sb.append(this.env_.filter("trans", "foo"));', $this->compile('{{ "foo"|trans|raw }}'));
     }
 
     public function testCompileWithParameters()
@@ -27,7 +27,7 @@ class TransFilterCompilerTest extends BaseTestCase
         $this->addMessages(array('remaining' => '%nb% remaining'));
 
         $this->assertContains(
-            'sb.append(twig.filter.replace("%nb% remaining", {"%nb%": tmp_nb}));',
+            'sb.append(this.env_.filter("trans", "remaining", {"%nb%": tmp_nb}));',
             $this->compile('{{ "remaining"|trans({"%nb%": nb})|raw }}')
         );
     }

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=5.3.2",
         "jms/twig-js": "dev-master",
-        "symfony/framework-bundle": "2.*,<2.3"
+        "symfony/symfony": "2.*,<2.4"
     },
     "autoload": {
         "psr-0": { "JMS\\TwigJsBundle": "" }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,7 +9,7 @@
          processIsolation="false"
          stopOnFailure="false"
          syntaxCheck="false"
-         bootstrap="./../../../../app/bootstrap.php.cache"
+         bootstrap="./vendor/autoload.php"
 >
          
     <testsuites>


### PR DESCRIPTION
I do need to change dependency from symfony/framework-bundle to symfony/symfony. It perhaps a bit dangerous but otherwise unit tests was failing (and for other errors)...
